### PR TITLE
Add compress() and compressBound()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ https://github.com/facebook/zstd compiled to WebAssembly. For now only decompres
 
 ```typescript
 export const isLoaded: Promise<boolean>;
+export function compressBound(size: number): number;
+export function compress(buffer: Uint8Array, compressionLevel?: number): Buffer;
 export function decompress(buffer: Uint8Array, size: number): Buffer;
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,19 @@ emcc \
   vendor/zstd/lib/common/threading.c \
   vendor/zstd/lib/common/xxhash.c \
   vendor/zstd/lib/common/zstd_common.c \
+  vendor/zstd/lib/compress/fse_compress.c \
+  vendor/zstd/lib/compress/hist.c \
+  vendor/zstd/lib/compress/huf_compress.c \
+  vendor/zstd/lib/compress/zstd_compress.c \
+  vendor/zstd/lib/compress/zstd_compress_literals.c \
+  vendor/zstd/lib/compress/zstd_compress_sequences.c \
+  vendor/zstd/lib/compress/zstd_compress_superblock.c \
+  vendor/zstd/lib/compress/zstd_double_fast.c \
+  vendor/zstd/lib/compress/zstd_fast.c \
+  vendor/zstd/lib/compress/zstd_lazy.c \
+  vendor/zstd/lib/compress/zstd_ldm.c \
+  vendor/zstd/lib/compress/zstd_opt.c \
+  vendor/zstd/lib/compress/zstdmt_compress.c \
   vendor/zstd/lib/decompress/huf_decompress.c \
   vendor/zstd/lib/decompress/zstd_ddict.c \
   vendor/zstd/lib/decompress/zstd_decompress.c \

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 declare module "@foxglove/wasm-zstd" {
-  function decompress(buffer: Uint8Array, size: number): Buffer;
-  namespace decompress {
-    const isLoaded: Promise<boolean>;
-  }
-
-  export default decompress;
+  export const isLoaded: Promise<boolean>;
+  export function compressBound(size: number): number;
+  export function compress(buffer: Uint8Array, compressionLevel?: number): Buffer;
+  export function decompress(buffer: Uint8Array, size: number): Buffer;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,55 @@ let Module;
 function ensureLoaded() {
   if (!Module) {
     throw new Error(
-      `wasm-zstd has not finished loading. Please wait with "await decompress.isLoaded" before calling decompress`
+      `wasm-zstd has not finished loading. Please wait with "await isLoaded" before calling any methods`
     );
   }
 }
 
-module.exports = function decompress(src, destSize) {
+function compressBound(srcSize) {
+  ensureLoaded();
+  return Module._compressBound(srcSize);
+}
+
+function compress(src, compressionLevel) {
+  ensureLoaded();
+  const srcSize = src.byteLength;
+  const destSize = compressBound(srcSize);
+
+  const srcPointer = Module._malloc(srcSize);
+  const destPointer = Module._malloc(destSize);
+
+  // set a default compression level if none is provided
+  if (compressionLevel == undefined) {
+    compressionLevel = 3;
+  }
+
+  // create a view into the heap for our source buffer
+  const uncompressedHeap = new Uint8Array(Module.HEAPU8.buffer, srcPointer, srcSize);
+  // copy source buffer into the heap
+  uncompressedHeap.set(src);
+
+  // call the C function to compress the frame
+  const resultSize = Module._compress(destPointer, destSize, srcPointer, srcSize, compressionLevel);
+
+  try {
+    if (resultSize === -1) {
+      throw new Error("Error during compression");
+    }
+
+    // copy destination buffer out of the heap back into js land
+    const output = Buffer.allocUnsafe(resultSize);
+    Buffer.from(Module.HEAPU8.buffer).copy(output, 0, destPointer, destPointer + resultSize);
+    return output;
+  } finally {
+    // free the source buffer memory
+    Module._free(srcPointer);
+    // free destination buffer on the heap
+    Module._free(destPointer);
+  }
+}
+
+function decompress(src, destSize) {
   ensureLoaded();
   const srcSize = src.byteLength;
 
@@ -41,14 +84,21 @@ module.exports = function decompress(src, destSize) {
     // free destination buffer on the heap
     Module._free(destPointer);
   }
-};
+}
 
 // export a promise a consumer can listen to to wait
 // for the module to finish loading
 // module loading is async and can take
 // several hundred milliseconds...accessing the module
 // before it is loaded will throw an error
-module.exports.isLoaded = ModulePromise.then((mod) => mod["ready"].then(() => {}));
+const isLoaded = ModulePromise.then((mod) => mod["ready"].then(() => {}));
+
+module.exports = {
+  compressBound,
+  compress,
+  decompress,
+  isLoaded,
+};
 
 // Wait for the promise returned from ModuleFactory to resolve
 ModulePromise.then((mod) => {

--- a/src/wasm-zstd.c
+++ b/src/wasm-zstd.c
@@ -4,30 +4,40 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
+#include "../vendor/zstd/lib/zstd.h"
+#include <emscripten/emscripten.h>
 #include <stdio.h>
 #include <string.h>
-#include <emscripten/emscripten.h>
-#include "../vendor/zstd/lib/zstd.h"
 
-int main(int argc, char **argv)
-{
-}
+int main(int argc, char **argv) {}
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-  int EMSCRIPTEN_KEEPALIVE decompress(
-      char *dstBuffer, size_t dstSize, const void *srcBuffer, size_t srcSize)
-  {
-    const size_t result = ZSTD_decompress(dstBuffer, dstSize, srcBuffer, srcSize);
-    if (ZSTD_isError(result))
-    {
-      return -1;
-    }
-    return result;
+size_t EMSCRIPTEN_KEEPALIVE compressBound(size_t srcSize) {
+  return ZSTD_compressBound(srcSize);
+}
+
+int EMSCRIPTEN_KEEPALIVE compress(char *dstBuffer, size_t dstSize,
+                                  const void *srcBuffer, size_t srcSize,
+                                  int compressionLevel) {
+  const size_t result =
+      ZSTD_compress(dstBuffer, dstSize, srcBuffer, srcSize, compressionLevel);
+  if (ZSTD_isError(result)) {
+    return -1;
   }
+  return result;
+}
+
+int EMSCRIPTEN_KEEPALIVE decompress(char *dstBuffer, size_t dstSize,
+                                    const void *srcBuffer, size_t srcSize) {
+  const size_t result = ZSTD_decompress(dstBuffer, dstSize, srcBuffer, srcSize);
+  if (ZSTD_isError(result)) {
+    return -1;
+  }
+  return result;
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Public-Facing Changes**
- Export `{ isLoaded, compressBound, compress, decompress }` instead of `decompress`

**Description**
Adds compression methods and tests, and changes the module export to include several methods instead of only decompress()
