### PR TITLE
Upgrade to Yarn 4.12.0 for npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxglove/wasm-zstd",
   "version": "1.0.1",
-  "packageManager": "yarn@4.9.1",
+  "packageManager": "yarn@4.12.0",
   "main": "dist/index.js",
   "types": "index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Upgrade packageManager to yarn@4.12.0

Yarn 4.10.0+ adds OIDC authentication support for GitHub Actions and GitLab CI, enabling npm trusted publishing without long-lived tokens.

## Test plan

- CI passes

Made with [Cursor](https://cursor.com)